### PR TITLE
Remove is_admin

### DIFF
--- a/give-paymill.php
+++ b/give-paymill.php
@@ -25,7 +25,7 @@ LICENSING / UPDATES
 --------------------------------------------------------------------------*/
 
 function give_add_paymill_licensing() {
-	if ( class_exists( 'Give_License' ) && is_admin() ) {
+	if ( class_exists( 'Give_License' ) ) {
 		new Give_License( __FILE__, 'Paymill Gateway', GIVE_PAYMILL_VERSION, 'WordImpress', 'paymill_license_key' );
 	}
 }


### PR DESCRIPTION
This stops loading license object when running ajax or background process.
https://github.com/WordImpress/Give/pull/836
