### PR TITLE
fix: ensure Paymill asset path is correct #14

### DIFF
--- a/give-paymill.php
+++ b/give-paymill.php
@@ -657,7 +657,7 @@ function give_paymill_js() {
 	}
 
 	wp_enqueue_script( 'paymill-js', 'https://bridge.paymill.com', array( 'jquery' ) );
-	wp_enqueue_script( 'give-paymill-js', GIVE_PAYMILL_PLUGIN_URL . 'give-paymill.js', array(
+	wp_enqueue_script( 'give-paymill-js', GIVE_PAYMILL_PLUGIN_URL . 'assets/js/give-paymill.js', array(
 		'jquery',
 		'paymill-js'
 	), GIVE_PAYMILL_VERSION );


### PR DESCRIPTION
This is a simple enough issue where the asset path was not correct. Likely the assets got moved at some point and only the admin js asset uri was corrected at that time. This has been corrected and there are not errors in the console anymore. You may rest easy @raftaar1191. 😄 

Resolves: #14